### PR TITLE
Add multi-provider LLM support (Groq/Mistral/Cerebras)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,21 @@ EVOLUTION_BASE_URL=
 EVOLUTION_API_KEY=
 EVOLUTION_INSTANCE=
 
-# Groq LLM (comma-separated keys for rotation)
+# LLM Providers (comma-separated keys for rotation)
+# Groq is required; Mistral and Cerebras are optional
 GROQ_API_KEYS=
+# MISTRAL_API_KEYS=
+# CEREBRAS_API_KEYS=
+
+# Optional model overrides (defaults: groq=openai/gpt-oss-120b, mistral=mistral-small-latest, cerebras=llama-4-scout-17b-16e-instruct)
+# GROQ_MODEL=
+# MISTRAL_MODEL=
+# CEREBRAS_MODEL=
+
+# Task-to-provider routing (comma-separated task=provider pairs)
+# Tasks: classify_flow, classify_subroute, detect_topic_shift, extract_data, conversational_reply, summarize
+# Example: LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
+# LLM_TASK_ROUTING=
 
 # Optional
 WEBHOOK_SECRET=

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -35,9 +35,21 @@ EVOLUTION_BASE_URL=https://your-evolution-api.com
 EVOLUTION_API_KEY=your-evolution-api-key
 EVOLUTION_INSTANCE=your-instance-name
 
-# Groq API (comma-separated keys for rotation)
-# Create 3-5 free tier accounts for better rate limits
+# LLM Providers (comma-separated keys for rotation)
+# Groq is required; Mistral and Cerebras are optional
 GROQ_API_KEYS=gsk_key1,gsk_key2,gsk_key3
+# MISTRAL_API_KEYS=mk_key1,mk_key2
+# CEREBRAS_API_KEYS=ck_key1,ck_key2
+
+# Optional model overrides per provider
+# GROQ_MODEL=openai/gpt-oss-120b
+# MISTRAL_MODEL=mistral-small-latest
+# CEREBRAS_MODEL=llama-4-scout-17b-16e-instruct
+
+# Task-to-provider routing (comma-separated task=provider pairs)
+# Available tasks: classify_flow, classify_subroute, detect_topic_shift, extract_data, conversational_reply, summarize
+# Unspecified tasks default to groq
+# LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
 
 # Optional Configuration
 WEBHOOK_SECRET=your-optional-webhook-secret

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.95.3",
-        "groq-sdk": "^0.37.0",
         "next": "^15.3.0",
+        "openai": "^6.22.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zod": "^4.3.6"
@@ -1069,16 +1069,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
-    },
     "node_modules/@types/phoenix": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
@@ -1641,18 +1631,6 @@
         "win32"
       ]
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1675,18 +1653,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1916,12 +1882,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2012,6 +1972,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2110,18 +2071,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2274,15 +2223,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2310,6 +2250,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2400,6 +2341,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2409,6 +2351,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2446,6 +2389,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2458,6 +2402,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2940,15 +2885,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3090,45 +3026,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3179,6 +3081,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3203,6 +3106,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3290,6 +3194,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3297,36 +3202,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/groq-sdk": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-0.37.0.tgz",
-      "integrity": "sha512-lT72pcT8b/X5XrzdKf+rWVzUGW1OQSKESmL8fFN5cTbsf02gq6oFam4SVeNtzELt9cYE2Pt3pdGgSImuTbHFDg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
-      }
-    },
-    "node_modules/groq-sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/groq-sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -3384,6 +3259,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3396,6 +3272,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3411,21 +3288,13 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iceberg-js": {
@@ -4077,6 +3946,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4106,27 +3976,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4154,6 +4003,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4245,46 +4095,6 @@
           "optional": true
         },
         "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
           "optional": true
         }
       }
@@ -4410,6 +4220,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
+      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -5324,12 +5155,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -5538,31 +5363,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5717,6 +5517,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.95.3",
-    "groq-sdk": "^0.37.0",
     "next": "^15.3.0",
+    "openai": "^6.22.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.3.6"

--- a/src/lib/flows/generalSupport/v1/steps.ts
+++ b/src/lib/flows/generalSupport/v1/steps.ts
@@ -25,6 +25,7 @@ export const handleAwaitingProblem: StepHandler = async (ctx) => {
       correlationId: ctx.correlationId,
       jsonMode: false,
       maxTokens: 100,
+      task: "summarize",
     });
     summary = result.content.trim();
     if (!summary) {

--- a/src/lib/flows/unknown/v1/steps.ts
+++ b/src/lib/flows/unknown/v1/steps.ts
@@ -27,6 +27,7 @@ async function getConversationalReply(
       userPrompt: unknownConversationUserPrompt(text, chatHistory, turnCount),
       correlationId,
       jsonMode: false,
+      task: "conversational_reply",
     });
     return result.content.trim() || null;
   } catch (err) {

--- a/src/lib/llm/extractors.ts
+++ b/src/lib/llm/extractors.ts
@@ -59,6 +59,7 @@ async function extractWithLlm<T>(options: {
       userPrompt,
       correlationId,
       maxTokens: 200,
+      task: "extract_data",
     });
     rawContent = result.content;
   } catch (err) {

--- a/src/lib/llm/globalRouter.ts
+++ b/src/lib/llm/globalRouter.ts
@@ -25,6 +25,7 @@ export async function classifyFlow(
       systemPrompt: globalRouterSystemPrompt(),
       userPrompt: globalRouterUserPrompt(text, chatHistory),
       correlationId,
+      task: "classify_flow",
     });
     rawContent = result.content;
   } catch (err) {

--- a/src/lib/llm/index.ts
+++ b/src/lib/llm/index.ts
@@ -21,6 +21,8 @@ export {
   SUBROUTE_CONFIG,
 } from "./schemas";
 export { callLlm, SafetyOverrideError, type LlmCallOptions, type LlmCallResult } from "./client";
+export { type ProviderId } from "./providers";
+export { type LlmTask } from "./taskRouter";
 export { classifyFlow, type ClassifyFlowResult } from "./globalRouter";
 export { detectTopicShift } from "./topicShift";
 export {

--- a/src/lib/llm/providers.ts
+++ b/src/lib/llm/providers.ts
@@ -1,0 +1,85 @@
+export type ProviderId = "groq" | "mistral" | "cerebras";
+
+export interface ProviderConfig {
+  id: ProviderId;
+  baseURL: string;
+  model: string;
+  keys: string[];
+}
+
+interface ProviderDefaults {
+  baseURL: string;
+  model: string;
+  keysEnv: string;
+  modelEnv: string;
+  required: boolean;
+}
+
+const PROVIDER_DEFAULTS: Record<ProviderId, ProviderDefaults> = {
+  groq: {
+    baseURL: "https://api.groq.com/openai/v1",
+    model: "openai/gpt-oss-120b",
+    keysEnv: "GROQ_API_KEYS",
+    modelEnv: "GROQ_MODEL",
+    required: true,
+  },
+  mistral: {
+    baseURL: "https://api.mistral.ai/v1",
+    model: "mistral-small-latest",
+    keysEnv: "MISTRAL_API_KEYS",
+    modelEnv: "MISTRAL_MODEL",
+    required: false,
+  },
+  cerebras: {
+    baseURL: "https://api.cerebras.ai/v1",
+    model: "llama-4-scout-17b-16e-instruct",
+    keysEnv: "CEREBRAS_API_KEYS",
+    modelEnv: "CEREBRAS_MODEL",
+    required: false,
+  },
+};
+
+const providerCache = new Map<ProviderId, ProviderConfig>();
+
+const keyIndexes = new Map<ProviderId, number>();
+
+export function getProvider(id: ProviderId): ProviderConfig {
+  const cached = providerCache.get(id);
+  if (cached) return cached;
+
+  const defaults = PROVIDER_DEFAULTS[id];
+  const raw = process.env[defaults.keysEnv];
+
+  if (!raw) {
+    if (defaults.required) {
+      throw new Error(`Missing env var ${defaults.keysEnv}`);
+    }
+    throw new Error(
+      `Provider "${id}" not configured — set ${defaults.keysEnv}`,
+    );
+  }
+
+  const keys = raw.split(",").filter(Boolean);
+  if (keys.length === 0) {
+    throw new Error(`${defaults.keysEnv} is empty`);
+  }
+
+  const model = process.env[defaults.modelEnv] || defaults.model;
+
+  const config: ProviderConfig = {
+    id,
+    baseURL: defaults.baseURL,
+    model,
+    keys,
+  };
+
+  providerCache.set(id, config);
+  return config;
+}
+
+export function nextApiKey(provider: ProviderConfig): string {
+  const idx = keyIndexes.get(provider.id) ?? 0;
+  const key = provider.keys[idx % provider.keys.length];
+  keyIndexes.set(provider.id, (idx + 1) % provider.keys.length);
+  return key;
+}

--- a/src/lib/llm/subrouteRouter.ts
+++ b/src/lib/llm/subrouteRouter.ts
@@ -50,6 +50,7 @@ export async function classifySubroute(
       systemPrompt: subrouteRouterSystemPrompt(flow, subroutes),
       userPrompt: subrouteRouterUserPrompt(text, chatHistory),
       correlationId,
+      task: "classify_subroute",
     });
     rawContent = result.content;
   } catch (err) {

--- a/src/lib/llm/taskRouter.ts
+++ b/src/lib/llm/taskRouter.ts
@@ -1,0 +1,38 @@
+import type { ProviderId } from "./providers";
+
+export type LlmTask =
+  | "classify_flow"
+  | "classify_subroute"
+  | "detect_topic_shift"
+  | "extract_data"
+  | "conversational_reply"
+  | "summarize";
+
+const DEFAULT_PROVIDER: ProviderId = "groq";
+
+let routingMap: Map<LlmTask, ProviderId> | null = null;
+
+function parseRouting(): Map<LlmTask, ProviderId> {
+  const map = new Map<LlmTask, ProviderId>();
+  const raw = process.env.LLM_TASK_ROUTING;
+  if (!raw) return map;
+
+  for (const pair of raw.split(",")) {
+    const [task, provider] = pair.trim().split("=");
+    if (task && provider) {
+      map.set(task.trim() as LlmTask, provider.trim() as ProviderId);
+    }
+  }
+
+  return map;
+}
+
+export function getProviderForTask(task?: LlmTask): ProviderId {
+  if (!task) return DEFAULT_PROVIDER;
+
+  if (!routingMap) {
+    routingMap = parseRouting();
+  }
+
+  return routingMap.get(task) ?? DEFAULT_PROVIDER;
+}

--- a/src/lib/llm/topicShift.ts
+++ b/src/lib/llm/topicShift.ts
@@ -109,6 +109,7 @@ export async function detectTopicShift(
       systemPrompt: topicShiftSystemPrompt(),
       userPrompt: topicShiftUserPrompt(text, currentFlow, chatHistory),
       correlationId,
+      task: "detect_topic_shift",
     });
 
     let parsed: unknown;


### PR DESCRIPTION
Closes #7

## Summary
- Replace `groq-sdk` with `openai` SDK using dynamic `baseURL` per provider (Groq, Mistral, Cerebras — all OpenAI-compatible)
- Add task-based routing via `LLM_TASK_ROUTING` env var so each LLM task can target a different provider
- Migrate STT client to `openai` SDK, fully removing `groq-sdk` dependency
- With no new env vars set, behavior is identical to before (all tasks → Groq)

## Test plan
- [ ] `npm run build` passes with no type errors
- [ ] `npm run lint` passes clean
- [ ] Smoke test with Groq only (no new env vars): send a WhatsApp message, verify full pipeline works
- [ ] Add a second provider: set `MISTRAL_API_KEYS` and `LLM_TASK_ROUTING=classify_flow=mistral`, verify logs show `"provider":"mistral"` for flow classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)