### PR TITLE
Add Mistral Voxtral STT as alternative to Groq Whisper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ GROQ_API_KEYS=
 # MISTRAL_API_KEYS=
 # CEREBRAS_API_KEYS=
 
-# Optional model overrides (defaults: groq=openai/gpt-oss-120b, mistral=mistral-small-latest, cerebras=llama-4-scout-17b-16e-instruct)
+# Optional model overrides (defaults: groq=openai/gpt-oss-120b, mistral=mistral-small-latest, cerebras=gpt-oss-120b)
 # GROQ_MODEL=
 # MISTRAL_MODEL=
 # CEREBRAS_MODEL=
@@ -22,6 +22,9 @@ GROQ_API_KEYS=
 # Tasks: classify_flow, classify_subroute, detect_topic_shift, extract_data, conversational_reply, summarize
 # Example: LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
 # LLM_TASK_ROUTING=
+
+# STT (speech-to-text) provider: groq (default) or mistral
+# STT_PROVIDER=groq
 
 # Optional
 WEBHOOK_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Mistral Voxtral STT (`voxtral-mini-latest`) as alternative to Groq Whisper — switch via `STT_PROVIDER=mistral` env var (default remains `groq`). Provider-specific context hints: Groq uses `prompt`, Mistral uses `context_bias`
 - Multi-provider LLM support — Groq (default), Mistral, and Cerebras can now be used side-by-side via a unified OpenAI-compatible client (`openai` npm package replaces `groq-sdk`)
 - Provider configuration (`src/lib/llm/providers.ts`) with per-provider base URL, default model, and round-robin API key rotation
 - Task-based routing (`src/lib/llm/taskRouter.ts`) — `LLM_TASK_ROUTING` env var maps LLM tasks (classify_flow, extract_data, etc.) to providers; unspecified tasks default to Groq
@@ -24,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Spoken email normalization (`normalizeSpokenEmail`) — converts "arroba" → @, "ponto" → ., removes spaces for dictated email addresses
 
 ### Changed
+- Cerebras default model updated from `llama-4-scout-17b-16e-instruct` (non-existent) to `gpt-oss-120b` — the only viable production model after Feb 16 deprecations
 - LLM client (`src/lib/llm/client.ts`) and STT client (`src/lib/stt/client.ts`) migrated from `groq-sdk` to `openai` SDK with dynamic `baseURL` per provider
 - Rate limit detection changed from `instanceof RateLimitError` to universal `err.status === 429` (works across all OpenAI-compatible providers)
 - Groq-specific safety override detection (`json_validate_failed`) now isolated behind a provider check — only runs when `providerId === "groq"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,11 @@ Skipped when active_flow is "unknown" — the unknown flow handles intent classi
 - **Multi-provider**: Groq (default), Mistral, Cerebras — all via OpenAI-compatible API (`openai` npm package).
 - **Provider config**: `src/lib/llm/providers.ts` — per-provider base URL, model, key rotation.
 - **Task routing**: `src/lib/llm/taskRouter.ts` — `LLM_TASK_ROUTING` env var maps tasks to providers (e.g. `classify_flow=mistral`). Unset = all tasks use Groq.
-- **Default models**: Groq=`openai/gpt-oss-120b`, Mistral=`mistral-small-latest`, Cerebras=`llama-4-scout-17b-16e-instruct`. Override via `GROQ_MODEL`, `MISTRAL_MODEL`, `CEREBRAS_MODEL`.
+- **Default models**: Groq=`openai/gpt-oss-120b`, Mistral=`mistral-small-latest`, Cerebras=`gpt-oss-120b`. Override via `GROQ_MODEL`, `MISTRAL_MODEL`, `CEREBRAS_MODEL`.
 - **JSON mode** (jsonMode: true): default. Responses validated with Zod before use.
 - **Text mode** (jsonMode: false): conversational replies only (unknown flow).
 - **Key rotation**: per-provider round-robin, auto-retry on 429.
+- **STT provider**: `STT_PROVIDER` env var — `groq` (default, Whisper `whisper-large-v3`) or `mistral` (Voxtral `voxtral-mini-latest`). Groq uses `prompt` for context hints; Mistral uses `context_bias`.
 - **Temperature**: 0 — **Max tokens**: 500 — **Timeout**: 8s
 - **On invalid JSON**: log error, fall back to "unknown" flow, ask user to rephrase.
 - Prompts: `src/lib/llm/prompts.ts` — Schemas: `src/lib/llm/schemas.ts`

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -51,6 +51,10 @@ GROQ_API_KEYS=gsk_key1,gsk_key2,gsk_key3
 # Unspecified tasks default to groq
 # LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
 
+# STT (speech-to-text) provider: groq (default) or mistral
+# Groq uses whisper-large-v3; Mistral uses voxtral-mini-latest
+# STT_PROVIDER=groq
+
 # Optional Configuration
 WEBHOOK_SECRET=your-optional-webhook-secret
 LOG_LEVEL=debug

--- a/src/lib/llm/providers.ts
+++ b/src/lib/llm/providers.ts
@@ -32,7 +32,7 @@ const PROVIDER_DEFAULTS: Record<ProviderId, ProviderDefaults> = {
   },
   cerebras: {
     baseURL: "https://api.cerebras.ai/v1",
-    model: "llama-4-scout-17b-16e-instruct",
+    model: "gpt-oss-120b",
     keysEnv: "CEREBRAS_API_KEYS",
     modelEnv: "CEREBRAS_MODEL",
     required: false,

--- a/src/lib/stt/index.ts
+++ b/src/lib/stt/index.ts
@@ -1,1 +1,1 @@
-export { transcribeAudio } from "./client";
+export { transcribeAudio, type SttProviderId } from "./client";


### PR DESCRIPTION
## Summary
- Add `STT_PROVIDER` env var to switch STT between `groq` (default, Whisper `whisper-large-v3`) and `mistral` (Voxtral `voxtral-mini-latest`)
- Provider-specific context hints: Groq uses `prompt` param, Mistral uses `context_bias` param
- Fix Cerebras default model to `gpt-oss-120b` (prior value was non-existent)

## Test plan
- [x] `npm run build` — no type errors
- [x] `npm run lint` — clean
- [ ] Default behavior (no `STT_PROVIDER`): audio transcription uses Groq Whisper as before
- [ ] Set `STT_PROVIDER=mistral`: logs show `stt_provider: "mistral"`, transcription succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)