### PR TITLE
Add self-hosted LLM provider mafaltti (Llama 3.1 8B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,11 +12,13 @@ EVOLUTION_INSTANCE=
 GROQ_API_KEYS=
 # MISTRAL_API_KEYS=
 # CEREBRAS_API_KEYS=
+# MAFALTTI_API_KEYS=
 
 # Optional model overrides (defaults: groq=openai/gpt-oss-120b, mistral=mistral-small-latest, cerebras=gpt-oss-120b)
 # GROQ_MODEL=
 # MISTRAL_MODEL=
 # CEREBRAS_MODEL=
+# MAFALTTI_MODEL=
 
 # Task-to-provider routing (comma-separated task=provider pairs)
 # Tasks: classify_flow, classify_subroute, detect_topic_shift, extract_data, conversational_reply, summarize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Self-hosted LLM provider "mafaltti" — Llama 3.1 8B on a private VM, configured as a 4th OpenAI-compatible provider. Route tasks via `LLM_TASK_ROUTING=conversational_reply=mafaltti`
 - Mistral Voxtral STT (`voxtral-mini-latest`) as alternative to Groq Whisper — switch via `STT_PROVIDER=mistral` env var (default remains `groq`). Provider-specific context hints: Groq uses `prompt`, Mistral uses `context_bias`
 - Multi-provider LLM support — Groq (default), Mistral, and Cerebras can now be used side-by-side via a unified OpenAI-compatible client (`openai` npm package replaces `groq-sdk`)
 - Provider configuration (`src/lib/llm/providers.ts`) with per-provider base URL, default model, and round-robin API key rotation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,10 @@ NOT a static menu. Uses LLM in text mode (jsonMode: false) for natural conversat
 Skipped when active_flow is "unknown" — the unknown flow handles intent classification internally.
 
 ## LLM Conventions
-- **Multi-provider**: Groq (default), Mistral, Cerebras — all via OpenAI-compatible API (`openai` npm package).
+- **Multi-provider**: Groq (default), Mistral, Cerebras, Mafaltti (self-hosted) — all via OpenAI-compatible API (`openai` npm package).
 - **Provider config**: `src/lib/llm/providers.ts` — per-provider base URL, model, key rotation.
 - **Task routing**: `src/lib/llm/taskRouter.ts` — `LLM_TASK_ROUTING` env var maps tasks to providers (e.g. `classify_flow=mistral`). Unset = all tasks use Groq.
-- **Default models**: Groq=`openai/gpt-oss-120b`, Mistral=`mistral-small-latest`, Cerebras=`gpt-oss-120b`. Override via `GROQ_MODEL`, `MISTRAL_MODEL`, `CEREBRAS_MODEL`.
+- **Default models**: Groq=`openai/gpt-oss-120b`, Mistral=`mistral-small-latest`, Cerebras=`gpt-oss-120b`, Mafaltti=`llama3.1:8b-instruct-q4_K_M`. Override via `GROQ_MODEL`, `MISTRAL_MODEL`, `CEREBRAS_MODEL`, `MAFALTTI_MODEL`.
 - **JSON mode** (jsonMode: true): default. Responses validated with Zod before use.
 - **Text mode** (jsonMode: false): conversational replies only (unknown flow).
 - **Key rotation**: per-provider round-robin, auto-retry on 429.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -36,20 +36,22 @@ EVOLUTION_API_KEY=your-evolution-api-key
 EVOLUTION_INSTANCE=your-instance-name
 
 # LLM Providers (comma-separated keys for rotation)
-# Groq is required; Mistral and Cerebras are optional
+# Groq is required; Mistral, Cerebras, and Mafaltti are optional
 GROQ_API_KEYS=gsk_key1,gsk_key2,gsk_key3
 # MISTRAL_API_KEYS=mk_key1,mk_key2
 # CEREBRAS_API_KEYS=ck_key1,ck_key2
+# MAFALTTI_API_KEYS=your-self-hosted-key
 
 # Optional model overrides per provider
 # GROQ_MODEL=openai/gpt-oss-120b
 # MISTRAL_MODEL=mistral-small-latest
 # CEREBRAS_MODEL=llama-4-scout-17b-16e-instruct
+# MAFALTTI_MODEL=llama3.1:8b-instruct-q4_K_M
 
 # Task-to-provider routing (comma-separated task=provider pairs)
 # Available tasks: classify_flow, classify_subroute, detect_topic_shift, extract_data, conversational_reply, summarize
 # Unspecified tasks default to groq
-# LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
+# LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras,conversational_reply=mafaltti
 
 # STT (speech-to-text) provider: groq (default) or mistral
 # Groq uses whisper-large-v3; Mistral uses voxtral-mini-latest

--- a/docs/PROVIDER-SWITCHING-GUIDE.md
+++ b/docs/PROVIDER-SWITCHING-GUIDE.md
@@ -43,6 +43,7 @@ The LLM system supports three providers. By default, **all tasks use Groq**. You
 | **Groq** (default) | `openai/gpt-oss-120b` | `GROQ_MODEL` | Yes |
 | **Mistral** | `mistral-small-latest` | `MISTRAL_MODEL` | Yes |
 | **Cerebras** | `gpt-oss-120b` | `CEREBRAS_MODEL` | Yes |
+| **Mafaltti** (self-hosted) | `llama3.1:8b-instruct-q4_K_M` | `MAFALTTI_MODEL` | Self-hosted |
 
 ### LLM Tasks
 
@@ -70,6 +71,9 @@ LLM_TASK_ROUTING=classify_flow=mistral,classify_subroute=mistral,extract_data=ce
 
 # Route everything to Mistral
 LLM_TASK_ROUTING=classify_flow=mistral,classify_subroute=mistral,detect_topic_shift=mistral,extract_data=mistral,conversational_reply=mistral,summarize=mistral
+
+# Route conversational replies to self-hosted Mafaltti
+LLM_TASK_ROUTING=conversational_reply=mafaltti
 ```
 
 ### How to override models
@@ -92,6 +96,7 @@ CEREBRAS_MODEL=gpt-oss-120b
 - **Groq**: `GROQ_API_KEYS` (required)
 - **Mistral**: `MISTRAL_API_KEYS` (only needed if routing tasks to Mistral)
 - **Cerebras**: `CEREBRAS_API_KEYS` (only needed if routing tasks to Cerebras)
+- **Mafaltti**: `MAFALTTI_API_KEYS` (only needed if routing tasks to Mafaltti — self-hosted Llama 3.1 8B)
 
 All key env vars accept comma-separated values for round-robin rotation (e.g. `GROQ_API_KEYS=key1,key2,key3`).
 
@@ -106,6 +111,7 @@ All key env vars accept comma-separated values for round-robin rotation (e.g. `G
 GROQ_API_KEYS=gsk_key1,gsk_key2
 MISTRAL_API_KEYS=mk_key1,mk_key2
 CEREBRAS_API_KEYS=ck_key1,ck_key2
+MAFALTTI_API_KEYS=your-self-hosted-key
 
 # STT: groq (default) or mistral
 STT_PROVIDER=groq
@@ -117,6 +123,7 @@ LLM_TASK_ROUTING=classify_flow=mistral,extract_data=cerebras
 # GROQ_MODEL=openai/gpt-oss-120b
 # MISTRAL_MODEL=mistral-small-latest
 # CEREBRAS_MODEL=gpt-oss-120b
+# MAFALTTI_MODEL=llama3.1:8b-instruct-q4_K_M
 ```
 
 After any change, restart the dev server (`npm run dev`).

--- a/src/lib/llm/providers.ts
+++ b/src/lib/llm/providers.ts
@@ -1,4 +1,4 @@
-export type ProviderId = "groq" | "mistral" | "cerebras";
+export type ProviderId = "groq" | "mistral" | "cerebras" | "mafaltti";
 
 export interface ProviderConfig {
   id: ProviderId;
@@ -35,6 +35,13 @@ const PROVIDER_DEFAULTS: Record<ProviderId, ProviderDefaults> = {
     model: "gpt-oss-120b",
     keysEnv: "CEREBRAS_API_KEYS",
     modelEnv: "CEREBRAS_MODEL",
+    required: false,
+  },
+  mafaltti: {
+    baseURL: "https://llm-arm02.danilocarneiro.com/v1",
+    model: "llama3.1:8b-instruct-q4_K_M",
+    keysEnv: "MAFALTTI_API_KEYS",
+    modelEnv: "MAFALTTI_MODEL",
     required: false,
   },
 };


### PR DESCRIPTION
## Summary
- Add "mafaltti" as a 4th OpenAI-compatible LLM provider, pointing at a self-hosted Llama 3.1 8B instance (`llm-arm02.danilocarneiro.com`)
- New `ProviderId` entry in `providers.ts` with baseURL, default model, and key/model env vars
- Documentation updated across `.env.example`, `CLAUDE.md`, `ENVIRONMENT.md`, and `PROVIDER-SWITCHING-GUIDE.md`

## Test plan
- [x] `npm run build` — no type errors
- [x] `npm run lint` — clean
- [ ] Route a task to mafaltti (`LLM_TASK_ROUTING=conversational_reply=mafaltti`), send a message, verify logs show `provider: "mafaltti"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)